### PR TITLE
Add latest dependencies

### DIFF
--- a/retlab.gemspec
+++ b/retlab.gemspec
@@ -13,10 +13,13 @@ Gem::Specification.new do |spec|
   regex      = %r{^(_layouts|_includes|_sass|LICENSE|README)/i}
   spec.files = `git ls-files -z`.split("\x0").select { |f| f.match(regex) }
 
-  spec.add_development_dependency 'github-pages', '>= 89'
-  spec.add_development_dependency 'jekyll-avatar', '~> 0.4'
+  spec.add_runtime_dependency 'github-pages', '>= 167'
+  spec.add_runtime_dependency 'jekyll-avatar', '~> 0.5'
+  spec.add_runtime_dependency 'jekyll-feed', '~> 0.9'
+  spec.add_runtime_dependency 'jekyll-github-metadata', '~> 2.9'
+  spec.add_runtime_dependency 'jekyll-seo-tag', '~> 2.2'
   spec.add_development_dependency 'html-proofer', '~> 3.0'
-  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rubocop', '~> 0.40'
   spec.add_development_dependency 'rake', '~> 11.0'
 end


### PR DESCRIPTION
Avoid the following Liquid errors when using retlab theme with `remote-theme`:

```sh
Unknown tag 'seo' in /_layouts/default.html
Unknown tag 'feed_meta' in /_layouts/default.html
Unknown tag 'github_edit_link' included in /_layouts/post.html
Unknown tag 'avatar' included in /_layouts/post.html
```