### PR TITLE
Add checks if Google Analytics Username and Twitter Property ID is present, anonymize ip

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,9 +16,6 @@ disqus:
 # Google Analytics tracking id
 ga_username: UA-xxxxxxxx-x
 
-# Property to let google analytics anonymize the user's id
-anonymize_ip: false
-
 # Links to include on the contact page
 contact_links:
   - name: Twitter

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,9 @@ disqus:
 # Google Analytics tracking id
 ga_username: UA-xxxxxxxx-x
 
+# Property to let google analytics anonymize the user's id
+anonymize_ip: false
+
 # Links to include on the contact page
 contact_links:
   - name: Twitter

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,8 @@
 
     {% feed_meta %}
     {% seo %}
-
+    
+    {% if site.ga_username %}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -20,6 +21,7 @@
       ga('create', '{{ site.ga_username }}', 'auto');
       ga('send', 'pageview');
     </script>
+    {% endif %}
   </head>
   <body class="{{ page.layout }} post{{ page.id | slugify | prepend: "-"}}">
     <div class="container">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,9 +19,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', '{{ site.ga_username }}', 'auto');
-      {% if site.anonymize_ip %}
       ga('set', 'anonymizeIp', true);
-      {% endif %}
       ga('send', 'pageview');
     </script>
     {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -60,9 +60,10 @@
     </div><!--/.container-->
 
     <script src="{{ "/assets/js/bundle.js?=" | append: site.github.build_revision | relative_url }}"></script>
+    {% if site.twitter.property_id %}
     <script src="https://platform.twitter.com/oct.js" type="text/javascript"></script>
     <script type="text/javascript">twttr.conversion.trackPid('{{ site.twitter.property_id }}', { tw_sale_amount: 0, tw_order_quantity: 0 });</script>
-
+    {% endif %}
   </body>
 </html>
 <!-- Proudly Powered by GitHub Pages | Generated {{ site.time }} | Revision {{ site.github.build_revision }} -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,9 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', '{{ site.ga_username }}', 'auto');
+      {% if site.anonymize_ip %}
+      ga('set', 'anonymizeIp', true);
+      {% endif %}
       ga('send', 'pageview');
     </script>
     {% endif %}


### PR DESCRIPTION
@benbalter 
Hello.
I've made some changes regarding the Google Analytics and Twitter implementation.
Now the page is checking if the username or property_id is present and is only showing the implementation if they **are** present. I've also added a property to anonymize the user's ip in Google Analytics regarding the GDPR.

Thank you,
MagicMarvMan