### PR TITLE
Remove unused variable

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,5 +1,4 @@
 ---
 ---
 
-$url_base: "{{ site.url }}";
 @import "retlab";


### PR DESCRIPTION
In 9a25094510097cd750cf2ab4b3eb26b3ed43ddd4 you removed the only place where this variable is used. Seems like using relative paths everywhere is a good practice and this variable isn't needed.