### PR TITLE
clarify expected header image type

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
    remote_theme: benbalter/retlab
    ```
 
-2. Save a header image to `/assets/img/header.png`. It should be 400px by 1140px.
+2. Save a header image to `/assets/img/header.jpg`. It should be 400px by 1140px.
 
 ## Configuration
 


### PR DESCRIPTION
The current CSS expects a `.jpg` header image rather than a `.png`.

-----
[View rendered README.md](https://github.com/jamesrhea/piedocs/blob/patch-1/README.md)