### PR TITLE
footer_page => footer_pages typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ nav_pages:
   - contact.md
 
 # Pages to include in footer navigation
-footer_page:
+footer_pages:
   - books.md
   - fine-print.md
 


### PR DESCRIPTION
_includes/footer.html looks for `footer_pages`

-----
[View rendered README.md](https://github.com/deargle/retlab/blob/patch-1/README.md)